### PR TITLE
Support Toggle and Accessing Bunch Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ npm install --global alfred-bunch
 3. Click on the "Configure workflow and variables" button.
 4. Add the path to your Bunches folder in Workflow Environment Variables:
     - `bunchLocation`: `/Users/yourname/bunches`
+5. (Optional) Change bunch toggle to true if you want the Alfred Workflow to open/close the bunch based on the bunches state
+    - `bunchToggle`: `true`
 5. Click "Save"
 
 ## Usage
@@ -32,3 +34,7 @@ In Alfred, type `bn`, optionally filter the list by typing some keywords. Press 
 ## License
 
 MIT © [Matthew Johnson](https://github.com/mttjhn/alfred-bunch)
+
+## Contributors  
+
+[John Christopher](https://github.com/jgchristopher)

--- a/index.js
+++ b/index.js
@@ -6,6 +6,19 @@ const bunchToggle = (process.env.bunchToggle === 'true') ? true : false;
 
 const bunchCommand = bunchToggle === true ? 'toggle' : 'open';
 
+const bunchSettings = [
+    {
+        title: "Bunch Settings ...",
+        subtitle: "Show Bunch Preference Pane",
+        arg: `x-bunch://prefs`
+    },
+    {
+        title: "Refresh Your Bunches",
+        subtitle: "Use this if you changed any of your bunch files",
+        arg: `x-bunch://setPref?configDir=${bunchFolder}`
+    }
+];
+
 // Check the config
 if (!bunchFolder) {
     alfy.error("Missing configuration. Run bn-config with the full path to your bunches folder.");
@@ -37,7 +50,9 @@ else {
                 subtitle: 'Action to run this bunch.',
                 arg: `x-bunch://${bunchCommand}?bunch=` + x.toLowerCase()
             }));
-            alfy.output(resultList);
+
+            // prepend the bunch settings command and return the list
+            alfy.output(bunchSettings.concat(resultList));
         }
     });
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@ const alfy = require('alfy');
 const glob = require("glob");
 
 const bunchFolder = process.env.bunchesLocation;
+const bunchToggle = (process.env.bunchToggle === 'true') ? true : false;
+
+const bunchCommand = bunchToggle === true ? 'toggle' : 'open';
 
 // Check the config
 if (!bunchFolder) {
@@ -25,14 +28,14 @@ else {
                 .map(x => ({
                     title: x.toLowerCase(),
                     subtitle: 'Action to run this bunch.',
-                    arg: 'x-bunch://open?bunch=' + x.toLowerCase()
+                    arg: `x-bunch://${bunchCommand}?bunch=` + x.toLowerCase()
                 }));
             alfy.output(resultList);
         } else {
             var resultList = bunches.map(x => ({
                 title: x.toLowerCase(),
                 subtitle: 'Action to run this bunch.',
-                arg: 'x-bunch://open?bunch=' + x.toLowerCase()
+                arg: `x-bunch://${bunchCommand}?bunch=` + x.toLowerCase()
             }));
             alfy.output(resultList);
         }

--- a/info.plist
+++ b/info.plist
@@ -35,10 +35,31 @@
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>A26EEE90-A8FF-49E3-A687-83154998C38E</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>alfredfiltersresults</key>
 				<false/>
 				<key>alfredfiltersresultsmatchmode</key>
 				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
 				<key>argumenttrimmode</key>
 				<integer>0</integer>
 				<key>argumenttype</key>
@@ -77,30 +98,24 @@
 			<key>uid</key>
 			<string>72E158F4-F85A-451A-91D6-DB4B6D3969EA</string>
 			<key>version</key>
-			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>browser</key>
-				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>{query}</string>
-				<key>utf8</key>
-				<true/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
-			<key>uid</key>
-			<string>A26EEE90-A8FF-49E3-A687-83154998C38E</string>
-			<key>version</key>
-			<integer>1</integer>
+			<integer>3</integer>
 		</dict>
 	</array>
 	<key>readme</key>
-	<string></string>
+	<string>
+	## Directions:
+
+	### Configuration  
+	bunchFolder - (~/bunches) - This is the path to your bunches (defaults to `~/bunches`)
+	bunchToggle - (true/false) - If `true` it will toggle the selected bunch, either opening or closing depending on current state. (default to `false`)
+
+		
+	### Usage
+	1. trigger Alfred
+	2. type bn (You should see your list of bunches)
+	3. continue typing to reduce the list of bunches
+	4. Return will open/toggle the selected bunch.
+	</string>
 	<key>uidata</key>
 	<dict>
 		<key>72E158F4-F85A-451A-91D6-DB4B6D3969EA</key>
@@ -120,12 +135,15 @@
 	</dict>
 	<key>variables</key>
 	<dict>
+		<key>bunchToggle</key>
+		<string>true</string>
 		<key>bunchesLocation</key>
-		<string></string>
+		<string>/Users/johnchristopher/gitprojects/Bunches</string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>
 		<string>bunchesLocation</string>
+		<string>bunchToggle</string>
 	</array>
 	<key>version</key>
 	<string>1.0.3</string>

--- a/info.plist
+++ b/info.plist
@@ -138,7 +138,7 @@
 		<key>bunchToggle</key>
 		<string>true</string>
 		<key>bunchesLocation</key>
-		<string>/Users/johnchristopher/gitprojects/Bunches</string>
+		<string></string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>


### PR DESCRIPTION
This PR adds a couple of changes. 

1. It adds configuration option to support calling bunch using the toggle command instead of open.
2. It shows opening the bunch settings pane as the first option if just the keyword `bn` is typed

